### PR TITLE
Refactor song entity and repository

### DIFF
--- a/src/song/typeorm/entities/song.entity.ts
+++ b/src/song/typeorm/entities/song.entity.ts
@@ -33,8 +33,9 @@ export class SongEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  //una cancion puede no tener dance logs
   @OneToMany(() => DanceLogEntity, (danceLog) => danceLog.song)
-  danceLogs: DanceLogEntity[];
+  danceLogs?: DanceLogEntity[];
 
   @Column({ nullable: false, type: 'varchar' })
   name: string;
@@ -83,5 +84,5 @@ export class SongEntity {
     name: 'created_at',
     default: () => 'CURRENT_TIMESTAMP',
   })
-  createdAt: Date;
+  createdAt?: Date;
 }

--- a/src/song/typeorm/repositories/song.typeorm.repository.ts
+++ b/src/song/typeorm/repositories/song.typeorm.repository.ts
@@ -48,7 +48,7 @@ export class SongTypeormRepository implements SongRepository {
   }
 
   async save(song: Song): Promise<void> {
-    const songEntity = this.repository.create({
+    const songEntity: SongEntity = {
       id: song.getId(),
       level: song.getLevel(),
       perceivedLevel: song.getPerceivedLevel(),
@@ -56,7 +56,7 @@ export class SongTypeormRepository implements SongRepository {
       name: song.getName(),
       kcalsAverage: song.getKcalsAverage(),
       bodyImpact: song.getBodyImpact(),
-    });
+    };
     await this.repository.save(songEntity);
 
     return void 0;


### PR DESCRIPTION
This commit refactors the `SongEntity` and `SongTypeormRepository` classes.

In the `SongEntity` class:
- The `danceLogs` property is now optional, as a song can have no dance logs.

In the `SongTypeormRepository` class:
- The `save` method now directly assigns the properties of the `song` parameter to the `songEntity` object, instead of using `this.repository.create()`.